### PR TITLE
Use date command to get timezone

### DIFF
--- a/scripts/skype-wrapper
+++ b/scripts/skype-wrapper
@@ -45,7 +45,7 @@ prepare_docker_env_parameters() {
   ENV_VARS+=" --env=USER_GID=${USER_GID}"
   ENV_VARS+=" --env=DISPLAY"
   ENV_VARS+=" --env=XAUTHORITY=${XAUTH}"
-  ENV_VARS+=" --env=TZ=$(cat /etc/timezone)"
+  ENV_VARS+=" --env=TZ=$(date +%Z)"
 }
 
 prepare_docker_volume_parameters() {


### PR DESCRIPTION
Small update to use `date` command to get timezone instead make `cat` to `/etc/timezone`. This is much better cause not all distros have `/etc/timezone` file.
