### PR TITLE
Better fonts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7212620B \
  && echo "deb http://archive.canonical.com/ trusty partner" >> /etc/apt/sources.list \
  && dpkg --add-architecture i386 \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y pulseaudio:i386 skype:i386 \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y pulseaudio:i386 skype:i386 ttf-ubuntu-font-family \
  && rm -rf /var/lib/apt/lists/*
 
 COPY scripts/ /var/cache/skype/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,16 @@ create_user() {
   chown ${SKYPE_USER}:${SKYPE_USER} -R /home/${SKYPE_USER}
 }
 
+configure_user() {
+  # small fix to have much better fonts
+  mkdir /home/${SKYPE_USER}/.config
+  cat > /home/${SKYPE_USER}/.config/Trolltech.conf << EOF
+[Qt]
+font="Ubuntu,11,-1,5,50,0,0,0,0,0"
+EOF
+  chown ${SKYPE_USER}:${SKYPE_USER} /home/${SKYPE_USER}/.config/Trolltech.conf
+}
+
 grant_access_to_video_devices() {
   for device in /dev/video*
   do
@@ -62,6 +72,7 @@ case "$1" in
     ;;
   skype)
     create_user
+    configure_user
     grant_access_to_video_devices
     launch_skype $@
     ;;


### PR DESCRIPTION
By default Skype fonts are very ugly, this small fix improve fonts in much better look with Ubuntu fonts and Docker image only grows around 5 Mb.
