### PR TITLE
Set locale to en_US.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM sameersbn/ubuntu:14.04.20160121
 
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8  
+
 ENV SKYPE_USER=skype
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv 7212620B \


### PR DESCRIPTION
Setting the container's locale to en_US.UTF-8 (the default is POSIX) enables support for Unicode characters which I believe is useful for many users. It does result in a very slightly bigger image but I think it's a worthy trade-off.
