### PR TITLE
Really cleanup instances on start

### DIFF
--- a/scripts/skype-wrapper
+++ b/scripts/skype-wrapper
@@ -33,9 +33,10 @@ cleanup_stopped_skype_instances(){
     image="$(${SUDO} docker inspect -f {{.Config.Image}} ${c})"
     if [ "${image}" == "sameersbn/skype:latest" ]; then
       running=$(${SUDO} docker inspect -f {{.State.Running}} ${c})
-      if [ "${running}" != "true" ]; then
-        ${SUDO} docker rm "${c}" >/dev/null
+      if [ "${running}" = "true" ]; then
+        ${SUDO} docker stop "${c}" >/dev/null
       fi
+      ${SUDO} docker rm "${c}" >/dev/null
     fi
   done
 }


### PR DESCRIPTION
- If we have running instances we stop em
- Then remove all

It's a usable workaround for "no-tray" problem:
when we hide by mistake running instance
we just restart it.
