### PR TITLE
issue #29: fixed an issue with setting timezone on RHEL7

### DIFF
--- a/scripts/skype-wrapper
+++ b/scripts/skype-wrapper
@@ -46,7 +46,7 @@ prepare_docker_env_parameters() {
   ENV_VARS+=" --env=USER_GID=${USER_GID}"
   ENV_VARS+=" --env=DISPLAY"
   ENV_VARS+=" --env=XAUTHORITY=${XAUTH}"
-  ENV_VARS+=" --env=TZ=$(date +%Z)"
+  [[ -L /etc/localtime && -e /etc/localtime  ]] && ENV_VARS+=" --env=TZ=$(readlink /etc/localtime | sed 's/..\/usr\/share\/zoneinfo\///')" || ENV_VARS+=" --env=TZ=$(date +%Z)"
 }
 
 prepare_docker_volume_parameters() {


### PR DESCRIPTION
On RHEL/CentOS 7 /etc/localtime is a symlink to some file inside /usr/share/zoneinfo/ folder. Provided solution fixes the issue by adding simple extra checks and doesn't affects Debian-based hosts.